### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # eth-wizard
+
+[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/stake-house/eth-wizard/badge)](https://www.gitpoap.io/gh/stake-house/eth-wizard)
+
 An Ethereum validator installation wizard meant to guide anyone through the different steps to become a fully functional validator on the Ethereum network. It will install and configure all the software needed to become a validator. It will test your installation. It will help you avoid the common pitfalls.
 
 This project is part of [the larger StakeHouse community](https://github.com/stake-house/stakehouse).


### PR DESCRIPTION
Hey @remyroy, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie